### PR TITLE
Add dashboard resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ plan.out
 *.iml
 *.test
 *.iml
+.env
 
 website/vendor
 

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ require (
 	github.com/denniswebb/go-splunk v0.0.0-20180501164408-314ac98ea67d
 	github.com/gorilla/schema v1.0.2 // indirect
 	github.com/hashicorp/terraform v0.11.13
-	gopkg.in/resty.v1 v1.12.0 // indirect
+	gopkg.in/resty.v1 v1.12.0
 )

--- a/splunk/client.go
+++ b/splunk/client.go
@@ -35,7 +35,7 @@ type xmlSKey struct {
 
 func dashboardCreate(c *resty.Client, d *Dashboard) (r *Dashboard, err error) {
 	body := fmt.Sprintf("name=%s&eai:data=%s", d.Name, d.Data)
-	_, err = c.R().SetBody([]byte(body)).Post("serviceNS/admin/search/data/ui/views")
+	_, err = c.R().SetBody([]byte(body)).Post(fmt.Sprintf("serviceNS/%s/search/data/ui/views", c.UserInfo.Username))
 	if err != nil {
 		return r, err
 	}
@@ -46,7 +46,7 @@ func dashboardCreate(c *resty.Client, d *Dashboard) (r *Dashboard, err error) {
 }
 
 func dashboardRead(c *resty.Client, n string) (r *Dashboard, err error) {
-	resp, err := c.R().Get(fmt.Sprintf("serviceNS/admin/search/data/ui/views/%s", n))
+	resp, err := c.R().Get(fmt.Sprintf("serviceNS/%s/search/data/ui/views/%s", c.UserInfo.Username, n))
 	if err != nil {
 		return r, err
 	}

--- a/splunk/client.go
+++ b/splunk/client.go
@@ -1,0 +1,70 @@
+package splunk
+
+import (
+	"encoding/xml"
+	"fmt"
+
+	resty "gopkg.in/resty.v1"
+)
+
+type Dashboard struct {
+	Name string
+	Data string
+}
+
+type dashboardResponse struct {
+	Entry xmlEntry `xml:"entry"`
+}
+
+type xmlEntry struct {
+	Content xmlContent `xml:"content"`
+}
+
+type xmlContent struct {
+	SDict xmlSDict `xml:"s:dict"`
+}
+
+type xmlSDict struct {
+	Keys []xmlSKey `xml:"s:key"`
+}
+
+type xmlSKey struct {
+	Name  string `xml:"name,attr"`
+	Value string `xml:",chardata"`
+}
+
+func dashboardCreate(c *resty.Client, d *Dashboard) (r *Dashboard, err error) {
+	body := fmt.Sprintf("name=%s&eai:data=%s", d.Name, d.Data)
+	_, err = c.R().SetBody([]byte(body)).Post("serviceNS/admin/search/data/ui/views")
+	if err != nil {
+		return r, err
+	}
+
+	return dashboardRead(c, d.Name)
+
+	return r, err
+}
+
+func dashboardRead(c *resty.Client, n string) (r *Dashboard, err error) {
+	resp, err := c.R().Get(fmt.Sprintf("serviceNS/admin/search/data/ui/views/%s", n))
+	if err != nil {
+		return r, err
+	}
+
+	var dbr dashboardResponse
+	xml.Unmarshal(resp.Body(), &dbr)
+	keys := dbr.Entry.Content.SDict.Keys
+	var dbrData string
+	for _, n := range keys {
+		if n.Name == "eai:data" {
+			dbrData = n.Value
+		}
+	}
+
+	r = &Dashboard{
+		Name: n,
+		Data: dbrData,
+	}
+
+	return r, err
+}

--- a/splunk/config.go
+++ b/splunk/config.go
@@ -1,9 +1,12 @@
 package splunk
 
 import (
+	"crypto/tls"
+	"fmt"
 	"log"
 
 	"github.com/denniswebb/go-splunk/splunk"
+	resty "gopkg.in/resty.v1"
 )
 
 type Config struct {
@@ -17,5 +20,18 @@ type Config struct {
 func (c *Config) Client() (*splunk.Client, error) {
 	client := splunk.New(c.URL, c.Username, c.Password, c.InsecureSkipVerify)
 	log.Printf("[INFO] Splunk Client configured for: %s@%s", c.Username, c.URL)
+	return client, nil
+}
+
+// RestClient() returns a low-level REST client for accessing Splunk.
+func (c *Config) RestClient() (*resty.Client, error) {
+	client := resty.New().
+		SetBasicAuth(c.Username, c.Password).
+		SetHostURL(fmt.Sprintf("%s", c.URL)).
+		SetHeader("Content-Type", "application/x-www-form-urlencoded").
+		SetQueryParam("output_mode", "json").
+		SetMode("rest").
+		SetTLSClientConfig(&tls.Config{InsecureSkipVerify: c.InsecureSkipVerify})
+	log.Printf("[INFO] REST Client configured for: %s@%s", c.Username, c.URL)
 	return client, nil
 }

--- a/splunk/provider.go
+++ b/splunk/provider.go
@@ -40,6 +40,7 @@ func Provider() terraform.ResourceProvider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"splunk_saved_search": resourceSplunkSavedSearch(),
+			"splunk_dashboard":    resourceSplunkDashboard(),
 		},
 
 		ConfigureFunc: providerConfigure,
@@ -54,5 +55,10 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		InsecureSkipVerify: d.Get("insecure_skip_verify").(bool),
 	}
 
-	return config.Client()
+	_, err := config.Client()
+	if err != nil {
+		return config, err
+	}
+
+	return &config, nil
 }

--- a/splunk/resource_splunk_dashboard.go
+++ b/splunk/resource_splunk_dashboard.go
@@ -1,0 +1,71 @@
+package splunk
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	resty "gopkg.in/resty.v1"
+)
+
+func resourceSplunkDashboard() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSplunkDashboardCreate,
+		Read:   resourceSplunkDashboardRead,
+		Update: resourceSplunkDashboardUpdate,
+		Delete: resourceSplunkDashboardDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				ForceNew: true,
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"data": {
+				ForceNew: true,
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dashboardFromResourceData(d *schema.ResourceData) (r *Dashboard) {
+	r = &Dashboard{
+		Name: d.Get("name").(string),
+		Data: d.Get("data").(string),
+	}
+	return r
+}
+
+func resourceSplunkDashboardCreate(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*resty.Client)
+	db := dashboardFromResourceData(d)
+
+	log.Printf("[DEBUG] Splunk Dashboard create configuration: %#v", db)
+
+	r, err := dashboardCreate(c, db)
+	if err != nil {
+		return fmt.Errorf("Failed to create saved search: %s", err)
+	}
+
+	d.SetId(r.Name)
+
+	log.Printf("[INFO] Splunk Dashboard ID: %s", d.Id())
+
+	return resourceSplunkDashboardRead(d, meta)
+}
+
+func resourceSplunkDashboardRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceSplunkDashboardUpdate(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceSplunkDashboardDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}

--- a/splunk/resource_splunk_saved_search.go
+++ b/splunk/resource_splunk_saved_search.go
@@ -644,7 +644,7 @@ func resourceSplunkSavedSearch() *schema.Resource {
 }
 
 func resourceSplunkSavedSearchCreate(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(*splunk.Client)
+	c, _ := meta.(*Config).Client()
 
 	s := savedSearchFromResourceData(d)
 
@@ -665,7 +665,7 @@ func resourceSplunkSavedSearchCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceSplunkSavedSearchRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*splunk.Client)
+	client, _ := meta.(*Config).Client()
 	savedSearch, err := client.SavedSearchRead(d.Id())
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
@@ -821,7 +821,7 @@ func flattenAcl(a *splunk.ACL) []interface{} {
 }
 
 func resourceSplunkSavedSearchUpdate(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(*splunk.Client)
+	c, _ := meta.(*Config).Client()
 
 	s := savedSearchFromResourceData(d)
 
@@ -848,7 +848,7 @@ func resourceSplunkSavedSearchAclUpdate(c *splunk.Client, s *splunk.SavedSearch)
 }
 
 func resourceSplunkSavedSearchDelete(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(*splunk.Client)
+	c, _ := meta.(*Config).Client()
 
 	log.Printf("[INFO] Deleting Splunk Saved Search: %s", d.Id())
 


### PR DESCRIPTION
This pull request is incomplete. It requires error-handling and tests. At present, I cant' actually see the dashboards it's creating -- but I am sure it's creating and destroying objects. They just don't show up in the splunk dashboards list yet.

The pull request adds the following resource:

```hcl
resource "splunk_dashboard" "test" {
  name = "my-dashboard-name"
  data = "<dashboard><label>my dashboard</label></dashboard>"
}
```

Test output from applying the above:

```
❯ tf apply
splunk_dashboard.test: Creating...
  data: "" => "<dashboard><label>test dashboard</label></dashboard>"
  name: "" => "testing_dashboard_2"
splunk_dashboard.test: Creation complete after 2s (ID: testing_dashboard_2)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

❯ tf show
splunk_dashboard.test:
  id = testing_dashboard_2
  data = <dashboard><label>test dashboard</label></dashboard>
  name = testing_dashboard_2

❯ tf destroy
splunk_dashboard.test: Refreshing state... (ID: testing_dashboard_2)

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  - destroy

Terraform will perform the following actions:

  - splunk_dashboard.test


Plan: 0 to add, 0 to change, 1 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

splunk_dashboard.test: Destroying... (ID: testing_dashboard_2)
splunk_dashboard.test: Destruction complete after 1s

Destroy complete! Resources: 1 destroyed.```